### PR TITLE
map-size-custom: hardcode legend symbols & use add_tmap

### DIFF
--- a/email_flood_monitoring.Rmd
+++ b/email_flood_monitoring.Rmd
@@ -59,13 +59,12 @@ The alerts status is determined based on forecast discharge values from Google's
 The map shows the gauge locations and the warning status by basin. For more details, including the estimated flood extent, please visit Google's [Flood Hub](https://sites.research.google/floods).
 
 ```{r MapBasins}
-# m_basin_alerts
-add_tmap(
+add_tmap_custom(
   plot_object = m_basin_alerts,
   alt = "Status Map",
   height = 3.75,
-  width = 5.5
-  # html_width = 650
+  width = 5.5,
+  html_width = 650
 )
 
 ```

--- a/email_flood_monitoring.Rmd
+++ b/email_flood_monitoring.Rmd
@@ -59,7 +59,15 @@ The alerts status is determined based on forecast discharge values from Google's
 The map shows the gauge locations and the warning status by basin. For more details, including the estimated flood extent, please visit Google's [Flood Hub](https://sites.research.google/floods).
 
 ```{r MapBasins}
-m_basin_alerts
+# m_basin_alerts
+add_tmap(
+  plot_object = m_basin_alerts,
+  alt = "Status Map",
+  height = 3.75,
+  width = 5.5
+  # html_width = 650
+)
+
 ```
 
 Below we see the average predicted discharge as a percentage of the 2 year return period value for 7 days for each basin. Each line represents one monitored basin.

--- a/src/gauge_monitoring_email.R
+++ b/src/gauge_monitoring_email.R
@@ -29,9 +29,9 @@ library(gghdx)
 library(rhdx)
 gghdx()
 
-source("R/email_funcs.R")
-source("src/email/email_utils.R")
-# source("R/utils.R")
+source(file.path("R","email_funcs.R"))
+source(file.path("src","email","email_utils.R"))
+
 
 # Get Data ----------------------------------------------------------------
 
@@ -151,14 +151,12 @@ df_basin_alert_status <- accum_pct_gauges_breached(
   mutate(
     `Basin alert status` = if_else(cum_pct >= 0.8, "Warning", "No warning")
   )
-# gauge_warning
 
 gdf_basin_alert_poly <- gdf_basins_poly %>%
   left_join(
     df_basin_alert_status,
     by = "basin_name"
   )
-gdf_basin_alert_poly[1,"Basin alert status"]<-"Warning"
 
 gdf_basin_alert_lines <- st_cast(gdf_basin_alert_poly, "MULTILINESTRING")
 
@@ -167,7 +165,7 @@ gdf_basin_alert_lines <- st_cast(gdf_basin_alert_poly, "MULTILINESTRING")
 m_basin_alerts <- nga_base_map(
   west_africa_adm0 = L$west_central_africa,
   country_fill = "white",
-  surrounding_fill = hdx_colors()["gray-dark"],
+  surrounding_fill = hdx_hex("gray-dark"),
   surrounding_label = NULL
 ) +
   tm_shape(
@@ -176,12 +174,12 @@ m_basin_alerts <- nga_base_map(
   tm_polygons(
     col = "Basin alert status",
     palette = c(
-      `No Warning` = hdx_colors()["mint-ultra-light"],
-      `Warning` = hdx_colors()["tomato-hdx"]
+      `No Warning` = hdx_hex("mint-ultra-light"),
+      `Warning` = hdx_hex("tomato-hdx")
     ),
     alpha = 0.5,
     border.col = NULL, 
-    legend.show=F
+    legend.show = FALSE
   ) +
   tm_shape(
     gdf_basin_alert_lines
@@ -190,25 +188,25 @@ m_basin_alerts <- nga_base_map(
     col = "Basin alert status",
     legend.col.show = F,
     palette = c(
-      hdx_colors()["mint-hdx"],
-      hdx_colors()["tomato-dark"]
+      hdx_hex("mint-hdx"),
+      hdx_hex("tomato-dark")
     ),
     lwd = 4, alpha = 0.3
   ) +
   tm_shape(L$admin_1) +
   tm_borders(
-    col = hdx_colors()["gray-dark"],
+    col = hdx_hex("gray-dark"),
     alpha = 0.2
   ) +
   tm_shape(L$river) +
   tm_lines(
-    col = hdx_colors()["sapphire-light"], # ["sapphire-hdx"],
+    col = hdx_hex("sapphire-light"), 
     lwd = 3,
     alpha = 0.5
   ) +
   # gauge locations
   tm_shape(gdf_gauge_pts,
-    legend.show = F
+    legend.show = FALSE
   ) +
   tm_dots(
     col = "Gauge status",
@@ -217,16 +215,17 @@ m_basin_alerts <- nga_base_map(
       "#bababaff",
       "black"
     ),
-    legend.show=F,
-    legend.size.show = F
+    legend.show= FALSE,
+    legend.size.show = FALSE
   ) +
   tm_shape(gdf_basin_alert_poly) +
-  tm_text(text = "basin_name", shadow = T) +
+  tm_text(text = "basin_name", shadow = TRUE) +
   tm_add_legend(type ="fill",
                 title = "Basin alert status",
                 labels= c("No warning","Warning"),
-                col = c(hdx_colors()["mint-hdx"],
-                        hdx_colors()["tomato-dark"]),
+                col = c(hdx_hex("mint-hdx"),
+                        hdx_hex("tomato-dark")
+                        ),
                 alpha = 0.5,
                 border.col="grey"
                 )+

--- a/src/gauge_monitoring_email.R
+++ b/src/gauge_monitoring_email.R
@@ -30,6 +30,7 @@ library(rhdx)
 gghdx()
 
 source("R/email_funcs.R")
+source("src/email/email_utils.R")
 # source("R/utils.R")
 
 # Get Data ----------------------------------------------------------------
@@ -150,15 +151,16 @@ df_basin_alert_status <- accum_pct_gauges_breached(
   mutate(
     `Basin alert status` = if_else(cum_pct >= 0.8, "Warning", "No warning")
   )
+# gauge_warning
 
 gdf_basin_alert_poly <- gdf_basins_poly %>%
   left_join(
     df_basin_alert_status,
     by = "basin_name"
   )
+gdf_basin_alert_poly[1,"Basin alert status"]<-"Warning"
 
 gdf_basin_alert_lines <- st_cast(gdf_basin_alert_poly, "MULTILINESTRING")
-
 
 # Alert Map ---------------------------------------------------------------
 
@@ -178,11 +180,11 @@ m_basin_alerts <- nga_base_map(
       `Warning` = hdx_colors()["tomato-hdx"]
     ),
     alpha = 0.5,
-    border.col = NULL
+    border.col = NULL, 
+    legend.show=F
   ) +
   tm_shape(
-    gdf_basin_alert_lines,
-    legend.show = F
+    gdf_basin_alert_lines
   ) +
   tm_lines(
     col = "Basin alert status",
@@ -215,10 +217,26 @@ m_basin_alerts <- nga_base_map(
       "#bababaff",
       "black"
     ),
+    legend.show=F,
     legend.size.show = F
   ) +
   tm_shape(gdf_basin_alert_poly) +
   tm_text(text = "basin_name", shadow = T) +
+  tm_add_legend(type ="fill",
+                title = "Basin alert status",
+                labels= c("No warning","Warning"),
+                col = c(hdx_colors()["mint-hdx"],
+                        hdx_colors()["tomato-dark"]),
+                alpha = 0.5,
+                border.col="grey"
+                )+
+  tm_add_legend(type ="symbol",
+                title = "Gauge status",
+                labels= c("No warning","Warning"),
+                col = c( "#bababaff",
+                         "black"),
+                border.col = "grey"
+                )+
   tm_layout(
     title.size = 1.2,
     outer.margins = c(0, 0, 0, 0),


### PR DESCRIPTION
Okay I think this should be an improvement to the legend. I sent you another test email, so hopefully it doesn't change in GHA runs.

- I switched the legend to be hardcoded to show all legend options regardless of basin/gauge status (i think this is better). 
- switched to`add_tmap()` in the rmd which seems to be working. 

I don't want to get into too many sizing details in this PR as we received feedback on more stuff to add to the legend which I can do as a separate PR after we discuss.