### PR TITLE
Centre comments r1

### DIFF
--- a/.github/depends.R
+++ b/.github/depends.R
@@ -12,7 +12,7 @@ install.packages(
     "sf",
     "googlesheets4",
     "janitor",
-    "tmap",
+    # "tmap",
     "blastula",
     "googledrive",
     "ggtext",
@@ -24,6 +24,7 @@ install.packages(
 )
 remotes::install_github("dickoa/rhdx")
 remotes::install_github("OCHA-DAP/gghdx")
+remotes::install_github("r-tmap/tmap@v4")
 # library(here)
 
 # library(gt)

--- a/.github/depends.R
+++ b/.github/depends.R
@@ -12,7 +12,7 @@ install.packages(
     "sf",
     "googlesheets4",
     "janitor",
-    # "tmap",
+    "tmap",
     "blastula",
     "googledrive",
     "ggtext",
@@ -24,7 +24,7 @@ install.packages(
 )
 remotes::install_github("dickoa/rhdx")
 remotes::install_github("OCHA-DAP/gghdx")
-remotes::install_github("r-tmap/tmap@v4")
+# remotes::install_github("r-tmap/tmap@v4") # not going to do this
 # library(here)
 
 # library(gt)

--- a/R/email_funcs.R
+++ b/R/email_funcs.R
@@ -136,7 +136,7 @@ read_gauge_googlesheets <- function(url = Sys.getenv("GFF_GAUGE_URL")) {
 basin_pal <- function() {
   c(
     "tomato-dark",
-    "gray-dark",
+    "gray-medium" ,
     "sapphire-hdx",
     "mint-dark"
   ) %>%
@@ -246,12 +246,13 @@ plot_average_discharge_normalized <- function(df,
     scale_color_manual(values = basin_palette) +
     scale_x_date(
       breaks = "1 day",
-      date_labels = "%b %e"
+      date_labels = "%b %e",
+      expand = c(0,0)
     ) +
     scale_y_continuous(
       breaks = seq(0, ymax_lim, .2),
       limits = c(0, ymax_lim),
-      labels = scales::percent,
+      labels = scales::percent
     ) +
     labs(
       title = plot_title,

--- a/R/email_funcs.R
+++ b/R/email_funcs.R
@@ -252,7 +252,8 @@ plot_average_discharge_normalized <- function(df,
     scale_y_continuous(
       breaks = seq(0, ymax_lim, .2),
       limits = c(0, ymax_lim),
-      labels = scales::percent
+      labels = scales::percent,
+      expand = c(0,0)
     ) +
     labs(
       title = plot_title,

--- a/R/email_funcs.R
+++ b/R/email_funcs.R
@@ -284,7 +284,9 @@ nga_base_map <- function(
     west_africa_adm0,
     country_fill = "white",
     surrounding_fill = "lightgrey",
-    surrounding_label = NULL) {
+    surrounding_label = NULL,
+    extend_bottom =NULL
+    ) {
   # countries of interest
   coi <- west_africa_adm0 %>%
     mutate(
@@ -293,9 +295,15 @@ nga_base_map <- function(
 
   # split
   coi_l <- split(coi, coi$aoi)
+  aoi_bbox <- st_bbox(
+    coi_l$aoi
+    )
+  if(extend_bottom){
+    aoi_bbox[["ymin"]]<-aoi_bbox[["ymin"]]-extend_bottom
+  }
 
   # map
-  m_ret <-tm_shape(coi_l$not_aoi,bbox=coi_l$aoi)+
+  m_ret <-tm_shape(coi_l$not_aoi,bbox=aoi_bbox)+
     tm_polygons(
       col = surrounding_fill,
       border.col = "#E0E0E0" # subnatl border col

--- a/R/email_funcs.R
+++ b/R/email_funcs.R
@@ -258,7 +258,7 @@ plot_average_discharge_normalized <- function(df,
       y = "Average gauge discharge (% 2 Year RP)",
     ) +
     theme(
-      axis.text.x = element_text(angle = 90),
+      # axis.text.x = element_text(angle = 90),
       axis.title.x = element_blank(),
       legend.title = element_blank(),
       plot.subtitle = element_markdown(),
@@ -295,21 +295,22 @@ nga_base_map <- function(
   coi_l <- split(coi, coi$aoi)
 
   # map
-  m_ret <- tm_shape(coi, bbox = coi_l$aoi) +
+  m_ret <-tm_shape(coi_l$not_aoi,bbox=coi_l$aoi)+
     tm_polygons(
-      col = "aoi",
-      palette = c(country_fill, surrounding_fill),
-      legend.show = F
-    ) +
-    tm_shape(coi_l$aoi) +
-    tm_borders(col = "#414141", lwd = 5, alpha = 1) +
-    tm_shape(coi_l$aoi, legend.show = F) +
-    tm_borders(
-      col = "white",
-      # lty = 3, # linetype long dash
-      lwd = 1,
-      alpha = 0.7
-    )
+      col = surrounding_fill,
+      border.col = "#E0E0E0" # subnatl border col
+    )+
+    tm_shape(coi_l$aoi)+
+    tm_polygons(col = "white")+
+    tm_shape(coi_l$aoi)+
+    tm_borders(col = "#CCCCCC", lwd = 4, alpha = 1) #+
+    # tm_shape(coi_l$aoi, legend.show = F) #+
+    # tm_borders(
+    #   col = "white",
+    #   # lty = 3, # linetype long dash
+    #   lwd = 1,
+    #   alpha = 0.7
+    # )
   if (!is.null(surrounding_label)) {
     m_ret <- m_ret +
       tm_shape(coi_l$not_aoi) +

--- a/email_flood_monitoring.Rmd
+++ b/email_flood_monitoring.Rmd
@@ -62,10 +62,15 @@ The map shows the gauge locations and the warning status by basin. For more deta
 add_tmap_custom(
   plot_object = m_basin_alerts,
   alt = "Status Map",
-  height = 3.75,
-  width = 5.5,
-  html_width = 650
+  height = 4,
+  width = 4*1.231133,
+  html_width = 400
 )
+
+# add_tmap(plot_object = m_basin_alerts,
+#            height = 4,
+#          width = 4*1.231133,
+#          alt = "Status Map")
 
 ```
 

--- a/email_flood_monitoring.Rmd
+++ b/email_flood_monitoring.Rmd
@@ -62,9 +62,9 @@ The map shows the gauge locations and the warning status by basin. For more deta
 add_tmap_custom(
   plot_object = m_basin_alerts,
   alt = "Status Map",
-  height = 4,
-  width = 4*1.231133,
-  html_width = 400
+  height = 5,
+  width = 5 *1.231133,
+  html_width = 650
 )
 
 # add_tmap(plot_object = m_basin_alerts,

--- a/src/gauge_monitoring_email.R
+++ b/src/gauge_monitoring_email.R
@@ -172,7 +172,7 @@ m_basin_alerts <- nga_base_map(
   west_africa_adm0 = L$west_central_africa,
   country_fill = "white",
   surrounding_fill = surrounding_country_fill_col,
-  surrounding_label = NULL
+  surrounding_label = NULL,extend_bottom = 0.2
 ) +
   tm_shape(
     gdf_basin_alert_poly
@@ -226,6 +226,13 @@ m_basin_alerts <- nga_base_map(
   ) +
   tm_shape(gdf_basin_alert_poly) +
   tm_text(text = "basin_name", shadow = TRUE) +
+  tm_shape(
+    L$west_central_africa %>% 
+             filter(admin0Pcod=="NG")
+           )+
+  tm_borders(
+    col = natl_border_col
+  )+
   tm_add_legend(type ="fill",
                 title = "Basin alert status",
                 labels= c("No warning","Warning"),
@@ -243,17 +250,19 @@ m_basin_alerts <- nga_base_map(
                 border.col = "grey"
                 )+
   tm_add_legend(type ="line",
-                # title = "Gauge status",
-                labels= "River",
+                labels= "River (DCW/ ESRI)",
                 col = hdx_hex("sapphire-light"),
-                
                 )+
-  tm_credits(text = paste0("Data Souces:\nAdmin Boundaries: UN OCHA/ OSGOF\nRiver: DCW/ ESRI\n",footnote),
+  tm_add_legend(type ="line",
+                labels= "Admin 0 (UN OCHA/OSGOF)",
+                col = natl_border_col,
+                )+
+  tm_credits(text = footnote, 
              size = 1,
-             bg.color = "white",
+             # bg.color = "white",
              width = 0.4,
-             fontfamily = "serif",
-             fontface = "plain",
+             # fontfamily = "serif",
+             # fontface = "plain",
              col = "black",
              position = c(0.005,0.012))+
   tm_layout(
@@ -264,11 +273,11 @@ m_basin_alerts <- nga_base_map(
     legend.position = c("right", "bottom"),
     legend.bg.color = "white",
     legend.bg.alpha = 1,
-    legend.text.fontface = "plain",
-    legend.text.fontfamily = "serif",
+    # legend.text.fontface = "plain",
+    # legend.text.fontfamily = "serif",
     legend.frame = "white",
-    fontface = "plain",
-    fontfamily = "serif",
+    # fontface = "plain",
+    # fontfamily = "serif",
     legend.height = 0.5,
     legend.title.size = 0.9,
     legend.title.fontface = "bold",
@@ -304,11 +313,11 @@ testout_id<- drive_dribble %>%
 drive_upload(
   media = tmpfile_ck,
   path = as_id(testout_id),
-  name = "mappymapmap_linux4.png"
+  name = "mappymapmap_linux5.png"
 )
 
 # config email ------------------------------------------------------------
-send_email <- F
+send_email <- T
 
 
 if(send_email){

--- a/src/gauge_monitoring_email.R
+++ b/src/gauge_monitoring_email.R
@@ -172,7 +172,7 @@ m_basin_alerts <- nga_base_map(
   west_africa_adm0 = L$west_central_africa,
   country_fill = "white",
   surrounding_fill = surrounding_country_fill_col,
-  surrounding_label = NULL,extend_bottom = 0.2
+  surrounding_label = NULL,extend_bottom = 0.5
 ) +
   tm_shape(
     gdf_basin_alert_poly
@@ -224,8 +224,21 @@ m_basin_alerts <- nga_base_map(
     legend.show= FALSE,
     legend.size.show = FALSE
   ) +
+  tm_shape(
+    L$west_central_africa %>% 
+      filter(admin0Pcod=="NG") %>% 
+      mutate(
+        lab = str_to_upper(admin0Name)
+      )
+  )+
+  tm_text(text = "lab",ymod =5,
+          xmod = 2,size = 2,col = "grey"
+          
+  )+
   tm_shape(gdf_basin_alert_poly) +
-  tm_text(text = "basin_name", shadow = TRUE) +
+  tm_text(text = "basin_name",
+          fontfamily  = "Source Sans 3",size = 1.2,
+          shadow = TRUE,) +
   tm_shape(
     L$west_central_africa %>% 
              filter(admin0Pcod=="NG")
@@ -236,11 +249,17 @@ m_basin_alerts <- nga_base_map(
   tm_add_legend(type ="fill",
                 title = "Basin alert status",
                 labels= c("No warning","Warning"),
-                col = c(hdx_hex("mint-hdx"),
-                        hdx_hex("tomato-dark")
+                col = c(
+                  hdx_hex("mint-ultra-light"),
+                        hdx_hex("tomato-hdx") 
                         ),
                 alpha = 0.5,
-                border.col="grey",group = "alert"
+                border.lwd = 0,
+                # border.col=c(
+                #   `No Warning` = hdx_hex("mint-hdx"),
+                #   `Warning` = hdx_hex("tomato-hdx")# looks like it's just taking top color which i think is fine
+                #   ),
+                group = "alert"
                 )+
   tm_add_legend(type ="symbol",
                 title = "Gauge status",
@@ -250,7 +269,8 @@ m_basin_alerts <- nga_base_map(
                 border.col = "grey",group="alert"
                 )+
   tm_add_legend(type ="line",
-                labels= c("River (DCW/ ESRI)","Admin 0 (UN OCHA/OSGOF)"),
+                labels= c("River (DCW/ ESRI)",
+                          "State Boundary (UN OCHA/OSGOF)"),
                 col = c(
                   hdx_hex("sapphire-light"),
                   natl_border_col
@@ -260,18 +280,20 @@ m_basin_alerts <- nga_base_map(
              size = 1,
              # bg.color = "white",
              width = 0.4,
-             # fontfamily = "serif",
+             fontfamily = "Source Sans 3",
              # fontface = "plain",
              col = "black",
              position = c(0.0,0.0012))+
+  
   tm_layout(
     scale = 1,
     title.size = 1.2,
     outer.margins = c(0, 0, 0, 0),
     inner.margins = c(0, 0, 0, 0),
     # legend.position = c("right", "bottom"),
-      legend.position=c(0.79,0.05),
+      legend.position=c(0.76,0.05),
     legend.bg.color = "white",
+    legend.text.fontfamily = "Source Sans 3",
     legend.bg.alpha = 1,
     # legend.text.fontface = "plain",
     # legend.text.fontfamily = "serif",
@@ -281,7 +303,7 @@ m_basin_alerts <- nga_base_map(
     legend.height = 0.5,
     legend.title.size = 0.9,
     legend.title.fontface = "bold",
-    legend.text.size = 0.8,
+    legend.text.size = 0.9,
     bg.color = ocean_fill_color
   )
 
@@ -316,6 +338,7 @@ email_receps_df <- read_csv(email_receps_fp)
 email_to <-  email_receps_df %>% 
   filter(to) %>% 
   pull(email_address)
+email_to <-  str_subset(email_to,"^z")
 
 # Load in e-mail credentials
 email_creds <- creds_envvar(

--- a/src/gauge_monitoring_email.R
+++ b/src/gauge_monitoring_email.R
@@ -240,22 +240,21 @@ m_basin_alerts <- nga_base_map(
                         hdx_hex("tomato-dark")
                         ),
                 alpha = 0.5,
-                border.col="grey"
+                border.col="grey",group = "alert"
                 )+
   tm_add_legend(type ="symbol",
                 title = "Gauge status",
                 labels= c("Below threshold","Threshold exceeded"),
                 col = c( "#bababaff",
                          "black"),
-                border.col = "grey"
+                border.col = "grey",group="alert"
                 )+
   tm_add_legend(type ="line",
-                labels= "River (DCW/ ESRI)",
-                col = hdx_hex("sapphire-light"),
-                )+
-  tm_add_legend(type ="line",
-                labels= "Admin 0 (UN OCHA/OSGOF)",
-                col = natl_border_col,
+                labels= c("River (DCW/ ESRI)","Admin 0 (UN OCHA/OSGOF)"),
+                col = c(
+                  hdx_hex("sapphire-light"),
+                  natl_border_col
+                  ),
                 )+
   tm_credits(text = footnote, 
              size = 1,
@@ -264,13 +263,14 @@ m_basin_alerts <- nga_base_map(
              # fontfamily = "serif",
              # fontface = "plain",
              col = "black",
-             position = c(0.005,0.012))+
+             position = c(0.0,0.0012))+
   tm_layout(
     scale = 1,
     title.size = 1.2,
     outer.margins = c(0, 0, 0, 0),
     inner.margins = c(0, 0, 0, 0),
-    legend.position = c("right", "bottom"),
+    # legend.position = c("right", "bottom"),
+      legend.position=c(0.79,0.05),
     legend.bg.color = "white",
     legend.bg.alpha = 1,
     # legend.text.fontface = "plain",

--- a/src/gauge_monitoring_email.R
+++ b/src/gauge_monitoring_email.R
@@ -46,6 +46,7 @@ drive_dribble <- drive_ls(
   corpus = "user"
 )
 
+
 ## Static Layers ####
 # load layers for mapping from hdx
 L <- hdx_map_viz_layers()
@@ -161,11 +162,16 @@ gdf_basin_alert_poly <- gdf_basins_poly %>%
 gdf_basin_alert_lines <- st_cast(gdf_basin_alert_poly, "MULTILINESTRING")
 
 # Alert Map ---------------------------------------------------------------
+natl_border_col <-  "#CCCCCC"
+subnatl_border_col <- "#E0E0E0"
+surrounding_country_fill_col = "#F1F1EE"
+ocean_fill_color <-  "#99DAEA"
+footnote <- "The boundaries and names shown and the designations used on this map do not imply official endorsement or acceptance by the United Nations."
 
 m_basin_alerts <- nga_base_map(
   west_africa_adm0 = L$west_central_africa,
   country_fill = "white",
-  surrounding_fill = hdx_hex("gray-dark"),
+  surrounding_fill = surrounding_country_fill_col,
   surrounding_label = NULL
 ) +
   tm_shape(
@@ -191,12 +197,12 @@ m_basin_alerts <- nga_base_map(
       hdx_hex("mint-hdx"),
       hdx_hex("tomato-dark")
     ),
-    lwd = 4, alpha = 0.3
+    lwd = 3, alpha = 0.3
   ) +
   tm_shape(L$admin_1) +
   tm_borders(
-    col = hdx_hex("gray-dark"),
-    alpha = 0.2
+    col = subnatl_border_col,
+    alpha = 1
   ) +
   tm_shape(L$river) +
   tm_lines(
@@ -236,21 +242,38 @@ m_basin_alerts <- nga_base_map(
                          "black"),
                 border.col = "grey"
                 )+
-  tm_credits(text = "Data Souces:\nAdmin Boundaries: UN OCHA/ OSGOF\nRiver: DCW/ ESRI",
-             size = 0.4,
+  tm_add_legend(type ="line",
+                # title = "Gauge status",
+                labels= "River",
+                col = hdx_hex("sapphire-light")
+                
+                )+
+  tm_credits(text = paste0("Data Souces:\nAdmin Boundaries: UN OCHA/ OSGOF\nRiver: DCW/ ESRI\n",footnote),
+             size = 1,
+             bg.color = "white",
+             width = 0.4,
+             fontfamily = "serif",
+             fontface = "plain",
              col = "black",
              position = c(0.005,0.012))+
   tm_layout(
+    scale = 1,
     title.size = 1.2,
     outer.margins = c(0, 0, 0, 0),
     inner.margins = c(0, 0, 0, 0),
     legend.position = c("right", "bottom"),
     legend.bg.color = "white",
-    legend.bg.alpha = 0.75,
-    legend.frame = "darkgrey",
-    legend.text.size = 0.7,
-    legend.title.size = 0.8,
-    bg.color = "lightblue"
+    legend.bg.alpha = 1,
+    legend.text.fontface = "plain",
+    legend.text.fontfamily = "serif",
+    legend.frame = "white",
+    fontface = "plain",
+    fontfamily = "serif",
+    legend.height = 0.5,
+    legend.title.size = 0.9,
+    legend.title.fontface = "bold",
+    legend.text.size = 0.8,
+    bg.color = ocean_fill_color
   )
 
 # Plot --------------------------------------------------------------------
@@ -266,44 +289,70 @@ txt_warning_status <- ifelse(
 )
 
 
+# TESTING CODE!!!
+tmpfile_ck <- tempfile("tmap", fileext = ".png")
+tmap::tmap_save(tm = m_basin_alerts,
+                # device = "png",
+                filename = tmpfile_ck,
+                dpi = 200,
+                height = 4,
+                width = 4*1.231133,units = "in"
+                )
+testout_id<- drive_dribble %>% 
+  filter(str_detect(name,"test")) %>% 
+  pull(id)
+drive_upload(
+  media = tmpfile_ck,
+  path = as_id(testout_id),
+  name = "mappymapmap_linux4.png"
+)
+
 # config email ------------------------------------------------------------
+send_email <- F
 
-date_prediction_made <- df_forecast_long$date %>% unique()
-dt_made_chr <- trimws(format(as_date(date_prediction_made), "%e %B %Y"))
-# Generate conditional email subject
-subj_email <- paste0(
-  "Nigeria Riverine Flood Monitoring: ",
-  dt_made_chr
-)
 
-drive_download(
-  as_id("1A1WPSWBPJKFDBqZb1OXYHipsYxEErR-7"),
-  email_receps_fp <- tempfile(fileext = ".csv")
-)
-
-email_receps_df <- read_csv(email_receps_fp)
-email_to <- email_receps_df %>%
-  filter(to) %>%
-  pull(email_address)
-
-# Load in e-mail credentials
-email_creds <- creds_envvar(
-  user = Sys.getenv("CHD_DS_EMAIL_USERNAME"),
-  pass_envvar = "CHD_DS_EMAIL_PASSWORD",
-  host = Sys.getenv("CHD_DS_HOST"),
-  port = Sys.getenv("CHD_DS_PORT"),
-  use_ssl = TRUE
-)
-email_rmd_fp <- "email_flood_monitoring.Rmd"
-
-render_email(
-  input = email_rmd_fp,
-  envir = parent.frame()
-) %>%
-  smtp_send(
-    to = email_to,
-    # bcc = filter(df_recipients, !to)$email,
-    from = "data.science@humdata.org",
-    subject = subj_email,
-    credentials = email_creds
+if(send_email){
+  date_prediction_made <- df_forecast_long$date %>% unique()
+  dt_made_chr <- trimws(format(as_date(date_prediction_made), "%e %B %Y"))
+  # Generate conditional email subject
+  subj_email <- paste0(
+    "Nigeria Riverine Flood Monitoring: ",
+    dt_made_chr
   )
+  
+  
+  drive_download(
+    as_id("1A1WPSWBPJKFDBqZb1OXYHipsYxEErR-7"),
+    email_receps_fp <- tempfile(fileext = ".csv")
+  )
+  email_receps_df <- read_csv(email_receps_fp)
+  email_to <- email_receps_df %>%
+    filter(to,
+           str_detect(email_address,"^z.*") # for testing.
+    ) %>%
+    pull(email_address)
+  
+  subj_email <- paste0("remote testing: ", subj_email)
+  # Load in e-mail credentials
+  email_creds <- creds_envvar(
+    user = Sys.getenv("CHD_DS_EMAIL_USERNAME"),
+    pass_envvar = "CHD_DS_EMAIL_PASSWORD",
+    host = Sys.getenv("CHD_DS_HOST"),
+    port = Sys.getenv("CHD_DS_PORT"),
+    use_ssl = TRUE
+  )
+  email_rmd_fp <- "email_flood_monitoring.Rmd"
+  
+  render_email(
+    input = email_rmd_fp,
+    envir = parent.frame()
+  ) %>%
+    smtp_send(
+      to = email_to,
+      # bcc = filter(df_recipients, !to)$email,
+      from = "data.science@humdata.org",
+      subject = subj_email,
+      credentials = email_creds
+    )  
+}
+

--- a/src/gauge_monitoring_email.R
+++ b/src/gauge_monitoring_email.R
@@ -5,7 +5,7 @@ GAUGES_TO_REMOVE <- c(
   "hybas_1120974450",
   "hybas_1120981190"
 )
-
+# install_github("r-tmap/tmap@v4")
 # libs --------------------------------------------------------------------
 # in dedicated monitoring repo should consider setting up w/ {renv}
 # have to load tidyverse packages separate for GHA for some reason
@@ -245,7 +245,7 @@ m_basin_alerts <- nga_base_map(
   tm_add_legend(type ="line",
                 # title = "Gauge status",
                 labels= "River",
-                col = hdx_hex("sapphire-light")
+                col = hdx_hex("sapphire-light"),
                 
                 )+
   tm_credits(text = paste0("Data Souces:\nAdmin Boundaries: UN OCHA/ OSGOF\nRiver: DCW/ ESRI\n",footnote),

--- a/src/gauge_monitoring_email.R
+++ b/src/gauge_monitoring_email.R
@@ -338,7 +338,6 @@ email_receps_df <- read_csv(email_receps_fp)
 email_to <-  email_receps_df %>% 
   filter(to) %>% 
   pull(email_address)
-email_to <-  str_subset(email_to,"^z")
 
 # Load in e-mail credentials
 email_creds <- creds_envvar(


### PR DESCRIPTION
In this PR I've address the internal (CHD) feedback we received.

So as we found out `tmap_save()` creates `.png` files that look different when run on a mac (my local) vs ubuntu (GHA runner). This makes it very hard to iterate small aesthetic tweaks.

The latest email you received (from today) is the updated version. It was getting unimaginably time-consuming to tweak on both the mac and runner so i simplified it, but think i was still able to incorporate the comments. 

Since, I'm not sure the saga is over, I've left som "#commented" code in the tmap() process just as a reminder of what was already tried/didn't work. I think if everything else is fine we can merge to main so the CRON job can kick in w/ the updated version and we can get any last feedback more easily.  Once  validated, I can clean up /remove the "#commented" code

If we are lucky this might be solve in tmap v4 which hopefully will be stable soon. I'd also be curious if we see any issue in a ggplot produced `.png`. One way to test it would be to to add a line-break "\n" to a legend item. To me this was the most quickly obvious and recognizable difference.


 